### PR TITLE
Potential fix for code scanning alert no. 30: Superfluous trailing arguments

### DIFF
--- a/clubs.html
+++ b/clubs.html
@@ -2316,7 +2316,7 @@ function searchClubs(query) {
         club.name.toLowerCase().includes(query.toLowerCase()) ||
         club.description?.toLowerCase().includes(query.toLowerCase())
     );
-    renderClub(filteredClubs);
+    renderClub();
 }
 
 // Add search functionality


### PR DESCRIPTION
Potential fix for [https://github.com/terentievNikita/clubs.html.01/security/code-scanning/30](https://github.com/terentievNikita/clubs.html.01/security/code-scanning/30)

To fix the issue, the superfluous argument `filteredClubs` passed to the `renderClub` function on line 2319 should be removed. This ensures that the function call matches the function's definition and avoids confusion or potential errors in the future.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
